### PR TITLE
- Fixed crashing bug when only one card in stack to swipe

### DIFF
--- a/tabula/lib/pages/play_screen.dart
+++ b/tabula/lib/pages/play_screen.dart
@@ -45,6 +45,7 @@ class _PlayScreenState extends State<PlayScreen> {
   Color colorRight = Colors.grey;
   Color colorLeft = Colors.grey;
   Color colorUp = Colors.grey;
+  int _visibleCards = 2;
 
   @override
   void initState() {
@@ -67,6 +68,10 @@ class _PlayScreenState extends State<PlayScreen> {
 
     cards = widget.session.collection.cards;
     super.initState();
+
+    if (widget.wrongIndexCardsCollection.length == 1) {
+      _visibleCards = 1;
+    }
   }
 
   @override
@@ -91,7 +96,7 @@ class _PlayScreenState extends State<PlayScreen> {
                       onEnd: _onEnd,
                       onSwipeDirectionChange: _onSwipeDirectionChange,
                       isLoop: false,
-                      numberOfCardsDisplayed: 2,
+                      numberOfCardsDisplayed: _visibleCards,
                       allowedSwipeDirection: AllowedSwipeDirection.only(
                           up: true, left: true, right: true, down: true),
                       backCardOffset: const Offset(25, 15),

--- a/tabula/lib/pages/statistic_screen.dart
+++ b/tabula/lib/pages/statistic_screen.dart
@@ -205,43 +205,49 @@ class _StatisticScreenState extends State<StatisticScreen> {
           ),
         ),
         const SizedBox(height: 10),
-        SizedBox(
-          width: 280.0,
-          child: ElevatedButton(
-            style: ButtonStyle(
+        Visibility(
+          visible: !widget.wrongCards.isEmpty, // Button ist sichtbar, wenn wrongCards nicht leer ist
+          child: SizedBox(
+            width: 280.0,
+            child: ElevatedButton(
+              style: ButtonStyle(
                 padding: const MaterialStatePropertyAll(EdgeInsets.all(20.0)),
                 backgroundColor: const MaterialStatePropertyAll(Colors.purple),
                 shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                    RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30.0),
-                ))),
-            onPressed: () {
-              widget.wrongCards.isEmpty
-                  ? null
-                  : Navigator.pushAndRemoveUntil(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => PlayScreen(
-                                collectionName: widget.collectionName,
-                                collectionImageURL: widget.collectionImageURL,
-                                session: PlaySession(),
-                                random: false,
-                                quick: false,
-                                takeFront: widget.takeFront,
-                                wrongIndexCardsCollection: widget.wrongCards,
-                              )), (r) {
-                      return false;
-                    });
-            },
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: const [
-                Icon(Icons.close),
-                Text(
-                  "retry unknown vokabularies",
-                  style: TextStyle(color: Colors.white),
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30.0),
+                  ),
                 ),
-              ],
+              ),
+              onPressed: () {
+                Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => PlayScreen(
+                      collectionName: widget.collectionName,
+                      collectionImageURL: widget.collectionImageURL,
+                      session: PlaySession(),
+                      random: false,
+                      quick: false,
+                      takeFront: widget.takeFront,
+                      wrongIndexCardsCollection: widget.wrongCards,
+                    ),
+                  ),
+                      (r) {
+                    return false;
+                  },
+                );
+              },
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: const [
+                  Icon(Icons.close),
+                  Text(
+                    "retry unknown vocabularies",
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
- "retry unknown vocabularies"-button only appears now when there are unknown vocabularies to swipe